### PR TITLE
ChatServer: Make class instantiable, refactor

### DIFF
--- a/chat/server/ChatServer.java
+++ b/chat/server/ChatServer.java
@@ -11,6 +11,7 @@ import java.util.Arrays;
 import chat.libs.User;
 import chat.libs.Connection;
 import java.util.Optional;
+import java.util.Collections;
 import java.io.IOException;
 
 import java.net.ServerSocket;
@@ -19,62 +20,78 @@ import java.net.Socket;
 
 public class ChatServer {
 
-  private static final Object lock = new Object();
-  private static List<User> users = new ArrayList<>();
+  /**
+   * Static fields
+   */
   private static final int PORT = 6666;
+  private static final int MAX_CAPACITY = 5;
 
-  public static void main(String[] args){
+  /**
+   * Fields
+   */
+  // TODO: Why not lock on 'users'?
+  private final Object lock = new Object();
+  private final ExecutorService threadPool;
+  private final ServerSocket serverSocket;
+  private final List<User> users;
 
-    ExecutorService threadPool = (ThreadPoolExecutor) Executors.newFixedThreadPool(5);
-    ServerSocket serverSocket = null;
-    Socket socket = null;
+  public ChatServer(final int port) throws IOException {
+    threadPool = Executors.newFixedThreadPool(MAX_CAPACITY);
+    serverSocket = new ServerSocket(port);
+    users = new ArrayList<>(MAX_CAPACITY);
 
-    try {
-      serverSocket = new ServerSocket(PORT);
-    }
-    catch (IOException e) {e.printStackTrace(); }
+    System.out.println("Starting server on port " + port + "...");
+  }
 
-    // System.out.println("Before con");
-    while (users.size() <= 5) {
+  public void acceptClients() {
+    // TODO: Is 'users' or 'threadPool' responsible for gatekeeping the capacity?
+    while (users.size() <= MAX_CAPACITY) {
+      try {
+        Socket clientSocket = serverSocket.accept();
+        System.out.println("A new connection from " + clientSocket + "!");
 
-      synchronized(serverSocket) {
-        try {
-          socket = serverSocket.accept(); // establishes connection
-        }
-        catch (IOException e) { e.printStackTrace(); }
+        // Spawn a new thread for that user
+        threadPool.submit(new ClientConnection(clientSocket));
+      } catch (IOException e) {
+        e.printStackTrace();
       }
-      System.out.println("After con: Found a new client!");
-
-      // Spawn a new thread for that user
-      threadPool.submit( new ClientConnection(socket) );
     }
   }
 
+  public static void main(String[] args) {
+    try {
+      ChatServer server = new ChatServer(PORT);
+      server.acceptClients();
+    } catch (IOException e) {
+      e.printStackTrace();
+    }
+  }
 
   // FOR HANDLING THE USER LIST
   // TODO: ReEntrant lock might be better than synchronized? Testing needed.
 
   // TODO: Handle (prevent) user name clashes in some fashion, and return false in that case
-  public static boolean addUser(User user) {
+  public boolean addUser(User user) {
     synchronized(lock) {
       users.add(user);
       return true;
     }
   }
 
-  public static void removeUser(User user) {
+  public void removeUser(User user) {
     synchronized(lock) {
       users.remove(user);
     }
   }
 
-  public static List<User> getUsers() {
+  public List<User> getUsers() {
     synchronized(lock) {
-      return users;
+      return Collections.unmodifiableList(users);
     }
   }
 
-  public static Optional<User> getUser(String userName) {
+  // TODO: Use Map<String, User> to avoid linear lookup.
+  public Optional<User> getUser(String userName) {
     synchronized(lock) {
       for (var u : users) {
         if ( u.getUserName().equals(userName) ) return Optional.of(u);

--- a/chat/server/ClientConnection.java
+++ b/chat/server/ClientConnection.java
@@ -6,27 +6,29 @@ import java.net.*;
 import chat.libs.protocol.Lexer;
 import chat.libs.Connection;
 
-
+// TODO: Maybe call this class ClientHandler to separate it from Connection?
 public class ClientConnection implements Runnable {
 
-  private Socket socket;
+  private final Socket socket;
 
   public ClientConnection(Socket socket) {
     this.socket = socket;
   }
 
   public void run() {
-      Connection con = new Connection(socket);
+    Connection con = new Connection(socket);
 
-      while (true) {
-        String str = "";
-        try {
-          str = con.in.readUTF();
-        }
-        catch(IOException e) {System.out.println(e);}
-
+    while (true) {
+      try {
+        String str = con.in.readUTF();
         System.out.println(str);
+      } catch (EOFException e) {
+        System.out.println("Client with socket " + socket + " closed the connection.");
+        return;
+      } catch (IOException e) {
+        e.printStackTrace();
+        return;
       }
-    
+    }
   }
 }


### PR DESCRIPTION
ChatServer:
 - Introduce `MAX_CAPACITY` for fixed thread pool size.
 - Use `final` keyword to private fields to avoid mutation.
 - Move server loop to `acceptClients()`.
 - Make user-related functions non-static.
 - Make sure `getUsers()` returns an unmodifiable copy of `users`.

ClientConnection:
 - Handle `EOFException` specifically.
 - Exit thread with `return;` when client exits.